### PR TITLE
style: make config values a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,26 @@
 # botbase
 
-This is a botbase project for [nextcord](https://github.com/nextcord/nextcord) Discord Python bots to reduce boilerplate.
+This is a bot base project for Discord python bots made with [nextcord](https://github.com/nextcord/nextcord) to reduce boilerplate.
 
 ## Config values
 
-`db_enabled: bool` default `True`
-
-`db_url: str` either this or name
-
-`db_name: str` either this or url
-
-`db_user: str` default `"ooliver"`
-
-`db_host str` default `"localhost"`
-
-`version: str` default `"0.0.0"`
-
-`aiohttp_enabled: bool` default `True`
-
-`colors: list[int]` default `[0x9966CC]`
-
-`blacklist_enabled: bool` default `True`
-
-`prefix: str | list[str]`
-
-`helpmsg: str` default [`defaulthelpmsg`](https://github.com/ooliver1/botbase/blob/main/botbase/botbase.py#L38-L47)
-
-`helpindex: str` default [`defaulthelpindex`](https://github.com/ooliver1/botbase/blob/main/botbase/botbase.py#L48-L50)
-
-`helptitle: str` default `"Help Me!"`
-
-`helpfields: dict[str, str]` default `{}`
-
-`helpinsert: str` default `""`
-
-`emojiset: Emojis[str, str]` default `Emojis()`
-
-`logchannel: int` default `None`
-
-`guild_ids: list[int]` default `None`
+| Key                 | Type               | Default                                          |
+| ------------------- | ------------------ | ------------------------------------------------ |
+| `db_enabled`        | `bool`             | `True`                                           |
+| `db_url`            | `str`              |                                                  |
+| `db_name`           | `str`              |                                                  |
+| `db_user`           | `str`              | `"ooliver"`                                      |
+| `db_host`           | `str`              | `"localhost"`                                    |
+| `version`           | `str`              | `"0.0.0"`                                        |
+| `aiohttp_enabled`   | `bool`             | `True`                                           |
+| `colours`           | `list[int]`        | `[0x9966CC]`                                     |
+| `blacklist_enabled` | `bool`             | `True`                                           |
+| `prefix`            | `str \| list[str]` | `None`                                           |
+| `helpmsg`           | `str`              | [`defaulthelpmsg`](botbase/botbase.py#L38-L47)   |
+| `helpindex`         | `str`              | [`defaulthelpindex`](botbase/botbase.py#L48-L50) |
+| `helptitle`         | `str`              | `"Help Me!"`                                     |
+| `helpfields`        | `dict[str, str]`   | `{}`                                             |
+| `helpinsert`        | `str`              | `""`                                             |
+| `emojiset`          | `Emojis[str, str]` | `Emojis[]`                                       |
+| `logchannel`        | `int`              | `None`                                           |
+| `guild_ids`         | `list[int]`        | `None`                                           |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a bot base project for Discord python bots made with [nextcord](https://
 | `db_host`           | `str`              | `"localhost"`                                    |
 | `version`           | `str`              | `"0.0.0"`                                        |
 | `aiohttp_enabled`   | `bool`             | `True`                                           |
-| `colours`           | `list[int]`        | `[0x9966CC]`                                     |
+| `colors`           | `list[int]`        | `[0x9966CC]`                                     |
 | `blacklist_enabled` | `bool`             | `True`                                           |
 | `prefix`            | `str \| list[str]` | `None`                                           |
 | `helpmsg`           | `str`              | [`defaulthelpmsg`](botbase/botbase.py#L38-L47)   |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a bot base project for Discord python bots made with [nextcord](https://
 | `db_host`           | `str`              | `"localhost"`                                    |
 | `version`           | `str`              | `"0.0.0"`                                        |
 | `aiohttp_enabled`   | `bool`             | `True`                                           |
-| `colors`           | `list[int]`        | `[0x9966CC]`                                     |
+| `colors`            | `list[int]`        | `[0x9966CC]`                                     |
 | `blacklist_enabled` | `bool`             | `True`                                           |
 | `prefix`            | `str \| list[str]` | `None`                                           |
 | `helpmsg`           | `str`              | [`defaulthelpmsg`](botbase/botbase.py#L38-L47)   |


### PR DESCRIPTION
This pull request makes the Config Values in the README.md file ~~less horrible~~ more readable and clean with a table.

**Notes:** There are 2 parts in the table that are empty under `Default` because I do not know what "this " is supposed to be in ` either this or name`