### PR TITLE
chore: bump version in __init__.py file

### DIFF
--- a/botbase/__init__.py
+++ b/botbase/__init__.py
@@ -15,7 +15,7 @@ from .wraps import (
 )
 from .models import CogBase
 
-__version__ = "1.17.7"
+__version__ = "1.20.0"
 
 
 getLogger(__name__).addHandler(NullHandler())


### PR DESCRIPTION
This pull request just changes the file module version in the `botbase/__init__.py` file from `1.17.7` to `1.20.0`